### PR TITLE
 Fix Tethering Client cannot resolve Dnscrypt 

### DIFF
--- a/common/service.sh
+++ b/common/service.sh
@@ -16,6 +16,8 @@ do
 		sleep 5
 		iptables -t nat -A OUTPUT -p tcp --dport 53 -j DNAT --to-destination 127.0.0.1:5353
 		iptables -t nat -A OUTPUT -p udp --dport 53 -j DNAT --to-destination 127.0.0.1:5353
+		iptables -t nat -A INPUT -p tcp --dport 53 -j DNAT --to-destination 127.0.0.1:5353
+		iptables -t nat -A INPUT -p udp --dport 53 -j DNAT --to-destination 127.0.0.1:5353
 		break;
 	else
 		sleep 5


### PR DESCRIPTION
Client that get connection from Tethering / Hotspot from Android AP will get Dnscrypt resolver with this fix

i have tested it